### PR TITLE
Add region protection check to elevator/teleport pad color GUI

### DIFF
--- a/src/main/java/me/dunescifye/lunaritems/LunarItems.java
+++ b/src/main/java/me/dunescifye/lunaritems/LunarItems.java
@@ -10,6 +10,7 @@ import me.dunescifye.lunaritems.files.*;
 import me.dunescifye.lunaritems.gui.ColorGUI;
 import me.dunescifye.lunaritems.listeners.*;
 import me.dunescifye.lunaritems.utils.BaseRaidersUtils;
+import me.dunescifye.lunaritems.utils.BentoBoxUtils;
 import me.dunescifye.lunaritems.utils.VaultUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
@@ -83,6 +84,7 @@ public final class LunarItems extends JavaPlugin {
     public static boolean griefPreventionEnabled, decentHologramsEnabled, factionsUUIDEnabled;
     public static boolean worldGuardEnabled;
     public static boolean baseRaidersEnabled;
+    public static boolean bentoBoxEnabled;
     public static boolean vaultEnabled;
 
     public static LunarItems getPlugin() {
@@ -139,6 +141,13 @@ public final class LunarItems extends JavaPlugin {
             if (BaseRaidersUtils.isAvailable()) {
                 logger.info("Detected BaseRaiders, enabling support for it.");
                 baseRaidersEnabled = true;
+            }
+        }
+        if (Bukkit.getPluginManager().isPluginEnabled("BentoBox")) {
+            BentoBoxUtils.init();
+            if (BentoBoxUtils.isAvailable()) {
+                logger.info("Detected BentoBox, enabling support for it.");
+                bentoBoxEnabled = true;
             }
         }
         if (VaultUtils.setupEconomy()) {

--- a/src/main/java/me/dunescifye/lunaritems/commands/TrashCommand.java
+++ b/src/main/java/me/dunescifye/lunaritems/commands/TrashCommand.java
@@ -4,6 +4,7 @@ import dev.jorel.commandapi.CommandAPICommand;
 import me.dunescifye.lunaritems.LunarItems;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -11,6 +12,7 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.PotionMeta;
 
 import java.util.HashMap;
 import java.util.UUID;
@@ -41,6 +43,15 @@ public class TrashCommand implements Listener {
             .register();
     }
 
+    private static boolean isProtectedItem(ItemStack item) {
+        if (!item.hasItemMeta()) return false;
+        if (item.getType() == Material.POTION && item.getItemMeta() instanceof PotionMeta
+            && !item.getItemMeta().getPersistentDataContainer().has(LunarItems.keyEIID)) {
+            return false;
+        }
+        return true;
+    }
+
     // Prevent any EI items from going into trash
     @EventHandler
     public void onInventoryClick(InventoryClickEvent e) {
@@ -52,9 +63,9 @@ public class TrashCommand implements Listener {
         final ItemStack clickedItem = e.getCurrentItem();
 
         if (e.getRawSlot() < 54) {
-            if (!cursorItem.hasItemMeta()) return;
+            if (!isProtectedItem(cursorItem)) return;
         } else {
-            if (!e.getClick().isShiftClick() || clickedItem == null || !clickedItem.hasItemMeta()) return;
+            if (!e.getClick().isShiftClick() || clickedItem == null || !isProtectedItem(clickedItem)) return;
         }
         e.setCancelled(true);
         p.sendMessage(message);
@@ -67,7 +78,7 @@ public class TrashCommand implements Listener {
         if (!inv.equals(inventories.get(uuid))) return;
         inventories.remove(uuid);
         for (ItemStack item : inv.getContents()) { // Give the player any EI items that somehow made it into the trash
-            if (item == null || !item.hasItemMeta()) continue;
+            if (item == null || !isProtectedItem(item)) continue;
             e.getPlayer().getInventory().addItem(item);
         }
     }

--- a/src/main/java/me/dunescifye/lunaritems/files/BlocksConfig.java
+++ b/src/main/java/me/dunescifye/lunaritems/files/BlocksConfig.java
@@ -27,6 +27,7 @@ public class BlocksConfig {
     public static String colorChangeSuccessMessage;
     public static String colorChangeNoPermissionMessage;
     public static String colorChangeNoMoneyMessage;
+    public static String colorChangeBypassPermission;
     public static Map<String, ColorOption> colorOptions = new LinkedHashMap<>();
 
     public static class ColorOption {
@@ -102,6 +103,7 @@ public class BlocksConfig {
             config.addDefault("color_gui.success_message", "&aSuccessfully changed color to %color%!");
             config.addDefault("color_gui.no_permission_message", "&cYou don't have permission to use this color!");
             config.addDefault("color_gui.no_money_message", "&cYou need %cost% to change to this color!");
+            config.addDefault("color_gui.bypass_permission", "lunaritems.colorchange.bypass");
 
             // Default color options
             setupDefaultColorOption(config, "white", Material.WHITE_CONCRETE, Material.WHITE_SHULKER_BOX, "&fWhite", 0, 0, "lunaritems.color.white");
@@ -135,6 +137,7 @@ public class BlocksConfig {
         colorChangeSuccessMessage = ConfigUtils.setupConfig("color_gui.success_message", config, "&aSuccessfully changed color to %color%!");
         colorChangeNoPermissionMessage = ConfigUtils.setupConfig("color_gui.no_permission_message", config, "&cYou don't have permission to use this color!");
         colorChangeNoMoneyMessage = ConfigUtils.setupConfig("color_gui.no_money_message", config, "&cYou need %cost% to change to this color!");
+        colorChangeBypassPermission = ConfigUtils.setupConfig("color_gui.bypass_permission", config, "lunaritems.colorchange.bypass");
 
         // Load color options
         ConfigurationSection colorsSection = config.getConfigurationSection("color_gui.colors");

--- a/src/main/java/me/dunescifye/lunaritems/listeners/BlockBreakListener.java
+++ b/src/main/java/me/dunescifye/lunaritems/listeners/BlockBreakListener.java
@@ -369,34 +369,6 @@ public class BlockBreakListener implements Listener {
 
                 if (itemID.contains("jollyaxe")) {
                     drops = breakInFacing(b, radius, depth, p, axePredicates);
-                    // Custom Drops
-                    if (customDrop != null && !customDrop.isEmpty()) {
-                        Material log = Material.getMaterial(customDrop + "_LOG");
-                        Material strippedLog = Material.getMaterial("STRIPPED_" + customDrop + "_LOG");
-                        Material wood = Material.getMaterial(customDrop + "_WOOD");
-                        Material strippedWood = Material.getMaterial("STRIPPED_" + customDrop + "_WOOD");
-
-                        if (log != null && strippedLog != null && wood != null && strippedWood != null) {
-                            drops = drops.stream().map(drop -> {
-                                String dropString = drop.getType().toString();
-                                if (dropString.contains("LOG"))
-                                    return new ItemStack(dropString.contains("STRIPPED_") ? strippedLog : log,
-                                      drop.getAmount());
-                                else if (dropString.contains("WOOD"))
-                                    return new ItemStack(dropString.contains("STRIPPED_") ? strippedWood : wood,
-                                      drop.getAmount());
-                              return drop;
-                            }).collect(Collectors.toList());
-                        }
-                    }
-                    // Add to Inventory
-                    Inventory inv = p.getInventory();
-                    drops.removeIf(drop -> {
-                        String dropString = drop.getType().toString();
-                        if (dropString.contains("LOG") || dropString.contains("WOOD"))
-                            return inv.addItem(drop).isEmpty();
-                        return false;
-                    });
                 } else if (itemID.contains("amberlightpick")) {
                     drops = breakInFacing(b, radius, depth, p, pickaxePredicates);
                     // Put items in shulker

--- a/src/main/java/me/dunescifye/lunaritems/listeners/BlockBreakListener.java
+++ b/src/main/java/me/dunescifye/lunaritems/listeners/BlockBreakListener.java
@@ -8,6 +8,7 @@ import me.dunescifye.lunaritems.files.AncienttItemsConfig;
 import me.dunescifye.lunaritems.files.BlocksConfig;
 import me.dunescifye.lunaritems.files.Config;
 import me.dunescifye.lunaritems.utils.BlockUtils;
+import me.dunescifye.lunaritems.utils.CooldownManager;
 import me.dunescifye.lunaritems.utils.FUtils;
 import me.dunescifye.lunaritems.utils.Utils;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
@@ -36,6 +37,7 @@ import org.bukkit.persistence.PersistentDataType;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
@@ -941,7 +943,11 @@ public class BlockBreakListener implements Listener {
                 //Testing claim
                 if (isInClaimOrWilderness(player, b.getLocation())) {
                     drops.addAll(b.getDrops(item));
-                    if (ThreadLocalRandom.current().nextInt(4) == 0) drops.addAll(b.getDrops(item));
+                    if (!CooldownManager.hasCooldown(CooldownManager.nightmarePickDoubleCDs, player.getUniqueId())
+                        && ThreadLocalRandom.current().nextInt(4) == 0) {
+                        drops.addAll(b.getDrops(item));
+                        CooldownManager.setCooldown(CooldownManager.nightmarePickDoubleCDs, player.getUniqueId(), Duration.ofMinutes(5));
+                    }
                     b.setType(Material.AIR);
                     this.veinMineOres25ChanceDouble(b, drops, material, player, item);
                 }

--- a/src/main/java/me/dunescifye/lunaritems/listeners/PlayerInteractListener.java
+++ b/src/main/java/me/dunescifye/lunaritems/listeners/PlayerInteractListener.java
@@ -59,8 +59,12 @@ public class PlayerInteractListener implements Listener {
 
             Player p = e.getPlayer();
 
-            // If sneaking, open color GUI
+            // If sneaking, open color GUI (with protection check)
             if (p.isSneaking()) {
+                if (!p.hasPermission(BlocksConfig.colorChangeBypassPermission)
+                    && !FUtils.isInClaimOrWilderness(p, b.getLocation())) {
+                    return;
+                }
                 new ColorGUI(p, b, blockID);
             }
         }

--- a/src/main/java/me/dunescifye/lunaritems/utils/BentoBoxUtils.java
+++ b/src/main/java/me/dunescifye/lunaritems/utils/BentoBoxUtils.java
@@ -1,0 +1,109 @@
+package me.dunescifye.lunaritems.utils;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.logging.Logger;
+
+/**
+ * Reflection-based wrapper for BentoBox API.
+ * Allows compilation without the BentoBox jar.
+ */
+public class BentoBoxUtils {
+
+    private static final Logger logger = Bukkit.getLogger();
+    private static boolean initialized = false;
+    private static boolean available = false;
+
+    // Reflection references
+    private static Object islandsManager;
+    private static Method getIslandAtMethod;
+    private static Method getMemberSetMethod;
+
+    /**
+     * Initialize the reflection hooks for BentoBox API.
+     * Call this once during plugin enable.
+     */
+    public static void init() {
+        if (initialized) return;
+        initialized = true;
+
+        try {
+            // Get BentoBox instance
+            Class<?> bentoBoxClass = Class.forName("world.bentobox.bentobox.BentoBox");
+            Method getInstanceMethod = bentoBoxClass.getMethod("getInstance");
+            Object bentoBox = getInstanceMethod.invoke(null);
+
+            // Get IslandsManager
+            Method getIslandsMethod = bentoBoxClass.getMethod("getIslands");
+            islandsManager = getIslandsMethod.invoke(bentoBox);
+
+            // Get getIslandAt(Location) method from IslandsManager
+            getIslandAtMethod = islandsManager.getClass().getMethod("getIslandAt", Location.class);
+
+            // Get getMemberSet() method from Island class
+            Class<?> islandClass = Class.forName("world.bentobox.bentobox.database.objects.Island");
+            getMemberSetMethod = islandClass.getMethod("getMemberSet");
+
+            available = true;
+            logger.info("[LunarItems] BentoBox: API initialized successfully!");
+        } catch (ClassNotFoundException e) {
+            logger.warning("[LunarItems] BentoBox: Class not found - " + e.getMessage());
+            available = false;
+        } catch (NoSuchMethodException e) {
+            logger.warning("[LunarItems] BentoBox: Method not found - " + e.getMessage());
+            available = false;
+        } catch (Exception e) {
+            logger.warning("[LunarItems] BentoBox: Error initializing - " + e.getMessage());
+            available = false;
+        }
+    }
+
+    /**
+     * Check if BentoBox API is available.
+     */
+    public static boolean isAvailable() {
+        return available;
+    }
+
+    /**
+     * Check if player has permission to modify blocks at location.
+     * Returns true if:
+     * - No island at location (wilderness)
+     * - Player is in the island's member set (owner, sub-owner, member, trusted)
+     *
+     * Returns false if:
+     * - Location is on an island and player is not a member
+     */
+    @SuppressWarnings("unchecked")
+    public static boolean hasPermission(Player player, Location location) {
+        if (!available) return true;
+
+        try {
+            // Get island at location - returns Optional<Island>
+            Object optionalIsland = getIslandAtMethod.invoke(islandsManager, location);
+
+            if (optionalIsland instanceof Optional<?> opt) {
+                if (opt.isEmpty()) {
+                    return true; // No island = wilderness, allow
+                }
+
+                Object island = opt.get();
+
+                // Get member set (includes owner, sub-owners, members, trusted)
+                Set<UUID> memberSet = (Set<UUID>) getMemberSetMethod.invoke(island);
+                return memberSet.contains(player.getUniqueId());
+            }
+
+            return true;
+        } catch (Exception e) {
+            logger.warning("[LunarItems] BentoBox: Error checking permission - " + e.getMessage());
+            return true;
+        }
+    }
+}

--- a/src/main/java/me/dunescifye/lunaritems/utils/BentoBoxUtils.java
+++ b/src/main/java/me/dunescifye/lunaritems/utils/BentoBoxUtils.java
@@ -4,10 +4,9 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
 import java.util.logging.Logger;
 
 /**
@@ -23,7 +22,9 @@ public class BentoBoxUtils {
     // Reflection references
     private static Object islandsManager;
     private static Method getIslandAtMethod;
-    private static Method getMemberSetMethod;
+    private static Method isAllowedMethod;
+    private static Method userGetInstanceMethod;
+    private static Object breakBlocksFlag;
 
     /**
      * Initialize the reflection hooks for BentoBox API.
@@ -46,9 +47,19 @@ public class BentoBoxUtils {
             // Get getIslandAt(Location) method from IslandsManager
             getIslandAtMethod = islandsManager.getClass().getMethod("getIslandAt", Location.class);
 
-            // Get getMemberSet(int) method from Island class - filters by minimum rank
+            // Get User.getInstance(Player) for converting Player to BentoBox User
+            Class<?> userClass = Class.forName("world.bentobox.bentobox.api.user.User");
+            userGetInstanceMethod = userClass.getMethod("getInstance", Player.class);
+
+            // Get Flags.BREAK_BLOCKS flag
+            Class<?> flagsClass = Class.forName("world.bentobox.bentobox.lists.Flags");
+            Field breakBlocksField = flagsClass.getField("BREAK_BLOCKS");
+            breakBlocksFlag = breakBlocksField.get(null);
+
+            // Get Island.isAllowed(User, Flag) method
             Class<?> islandClass = Class.forName("world.bentobox.bentobox.database.objects.Island");
-            getMemberSetMethod = islandClass.getMethod("getMemberSet", int.class);
+            Class<?> flagClass = Class.forName("world.bentobox.bentobox.api.flags.Flag");
+            isAllowedMethod = islandClass.getMethod("isAllowed", userClass, flagClass);
 
             available = true;
             logger.info("[LunarItems] BentoBox: API initialized successfully!");
@@ -71,20 +82,17 @@ public class BentoBoxUtils {
         return available;
     }
 
-    // BentoBox rank constants
-    private static final int MEMBER_RANK = 500;
-
     /**
-     * Check if player has permission to modify blocks at location.
+     * Check if player has permission to break blocks at location.
+     * Uses BentoBox's island flag system which respects per-island settings.
      * Returns true if:
      * - No island at location (wilderness)
-     * - Player is in the island's member set with rank >= MEMBER (owner, sub-owner, member)
+     * - Player is allowed to break blocks based on island's BREAK_BLOCKS flag setting
+     *   (respects island owner's configured rank permissions for trusted/member/etc.)
      *
      * Returns false if:
-     * - Location is on an island and player is not at least a member
-     * - Trusted players (rank 400) are excluded - they cannot break blocks
+     * - Location is on an island and player's rank is below the island's BREAK_BLOCKS threshold
      */
-    @SuppressWarnings("unchecked")
     public static boolean hasPermission(Player player, Location location) {
         if (!available) return true;
 
@@ -99,10 +107,12 @@ public class BentoBoxUtils {
 
                 Object island = opt.get();
 
-                // Get member set with minimum rank of MEMBER (500)
-                // This excludes TRUSTED (400) and lower ranks
-                Set<UUID> memberSet = (Set<UUID>) getMemberSetMethod.invoke(island, MEMBER_RANK);
-                return memberSet.contains(player.getUniqueId());
+                // Convert Player to BentoBox User
+                Object user = userGetInstanceMethod.invoke(null, player);
+
+                // Check if user is allowed to break blocks on this island
+                // This respects the island's BREAK_BLOCKS flag rank setting
+                return (boolean) isAllowedMethod.invoke(island, user, breakBlocksFlag);
             }
 
             return true;

--- a/src/main/java/me/dunescifye/lunaritems/utils/BentoBoxUtils.java
+++ b/src/main/java/me/dunescifye/lunaritems/utils/BentoBoxUtils.java
@@ -46,9 +46,9 @@ public class BentoBoxUtils {
             // Get getIslandAt(Location) method from IslandsManager
             getIslandAtMethod = islandsManager.getClass().getMethod("getIslandAt", Location.class);
 
-            // Get getMemberSet() method from Island class
+            // Get getMemberSet(int) method from Island class - filters by minimum rank
             Class<?> islandClass = Class.forName("world.bentobox.bentobox.database.objects.Island");
-            getMemberSetMethod = islandClass.getMethod("getMemberSet");
+            getMemberSetMethod = islandClass.getMethod("getMemberSet", int.class);
 
             available = true;
             logger.info("[LunarItems] BentoBox: API initialized successfully!");
@@ -71,14 +71,18 @@ public class BentoBoxUtils {
         return available;
     }
 
+    // BentoBox rank constants
+    private static final int MEMBER_RANK = 500;
+
     /**
      * Check if player has permission to modify blocks at location.
      * Returns true if:
      * - No island at location (wilderness)
-     * - Player is in the island's member set (owner, sub-owner, member, trusted)
+     * - Player is in the island's member set with rank >= MEMBER (owner, sub-owner, member)
      *
      * Returns false if:
-     * - Location is on an island and player is not a member
+     * - Location is on an island and player is not at least a member
+     * - Trusted players (rank 400) are excluded - they cannot break blocks
      */
     @SuppressWarnings("unchecked")
     public static boolean hasPermission(Player player, Location location) {
@@ -95,8 +99,9 @@ public class BentoBoxUtils {
 
                 Object island = opt.get();
 
-                // Get member set (includes owner, sub-owners, members, trusted)
-                Set<UUID> memberSet = (Set<UUID>) getMemberSetMethod.invoke(island);
+                // Get member set with minimum rank of MEMBER (500)
+                // This excludes TRUSTED (400) and lower ranks
+                Set<UUID> memberSet = (Set<UUID>) getMemberSetMethod.invoke(island, MEMBER_RANK);
                 return memberSet.contains(player.getUniqueId());
             }
 

--- a/src/main/java/me/dunescifye/lunaritems/utils/CooldownManager.java
+++ b/src/main/java/me/dunescifye/lunaritems/utils/CooldownManager.java
@@ -17,6 +17,7 @@ public class CooldownManager {
     public static final Map<UUID, Instant> nexusHoeCooldowns = new HashMap<>();
     public static final Map<UUID, Instant> seraphimXpCDs = new HashMap<>();
     public static final Map<UUID, Instant> erosPickCDs = new HashMap<>();
+    public static final Map<UUID, Instant> nightmarePickDoubleCDs = new HashMap<>();
 
     // Set cooldown
     public static void setCooldown(Map<UUID, Instant> map, UUID key, Duration duration) {

--- a/src/main/java/me/dunescifye/lunaritems/utils/FUtils.java
+++ b/src/main/java/me/dunescifye/lunaritems/utils/FUtils.java
@@ -54,7 +54,15 @@ public class FUtils {
         }
         // Check BaseRaiders (FiveK protection)
         if (LunarItems.baseRaidersEnabled) {
-          return BaseRaidersUtils.hasPermission(player, location, "break");
+            if (!BaseRaidersUtils.hasPermission(player, location, "break")) {
+                return false;
+            }
+        }
+        // Check BentoBox (island protection)
+        if (LunarItems.bentoBoxEnabled) {
+            if (!BentoBoxUtils.hasPermission(player, location)) {
+                return false;
+            }
         }
         //if (LunarItems.factionsUUIDEnabled) {
         //    return playerCanBuildDestroyBlock(player, location, "destroy", true);

--- a/src/main/java/me/dunescifye/lunaritems/utils/FUtils.java
+++ b/src/main/java/me/dunescifye/lunaritems/utils/FUtils.java
@@ -2,9 +2,6 @@ package me.dunescifye.lunaritems.utils;
 
 import com.jeff_media.customblockdata.CustomBlockData;
 import me.dunescifye.lunaritems.LunarItems;
-import me.ryanhamshire.GriefPrevention.Claim;
-import me.ryanhamshire.GriefPrevention.ClaimPermission;
-import me.ryanhamshire.GriefPrevention.GriefPrevention;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -45,10 +42,9 @@ public class FUtils {
         dropAllItemStacks(center.getWorld(), center.getLocation(), drops);
     }
     public static boolean isInClaimOrWilderness(final Player player, final Location location) {
-        // Check GriefPrevention first
+        // Check GriefPrevention first (isolated class to avoid NoClassDefFoundError)
         if (LunarItems.griefPreventionEnabled) {
-            final Claim claim = GriefPrevention.instance.dataStore.getClaimAt(location, true, null);
-            if (claim != null && !claim.getOwnerID().equals(player.getUniqueId()) && !claim.hasExplicitPermission(player, ClaimPermission.Build)) {
+            if (!GriefPreventionUtils.hasPermission(player, location)) {
                 return false;
             }
         }

--- a/src/main/java/me/dunescifye/lunaritems/utils/GriefPreventionUtils.java
+++ b/src/main/java/me/dunescifye/lunaritems/utils/GriefPreventionUtils.java
@@ -1,0 +1,23 @@
+package me.dunescifye.lunaritems.utils;
+
+import me.ryanhamshire.GriefPrevention.Claim;
+import me.ryanhamshire.GriefPrevention.ClaimPermission;
+import me.ryanhamshire.GriefPrevention.GriefPrevention;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+/**
+ * Isolated GriefPrevention utility class.
+ * Only loaded when GriefPrevention is present on the server,
+ * preventing NoClassDefFoundError in FUtils.
+ */
+public class GriefPreventionUtils {
+
+    public static boolean hasPermission(Player player, Location location) {
+        Claim claim = GriefPrevention.instance.dataStore.getClaimAt(location, true, null);
+        if (claim != null && !claim.getOwnerID().equals(player.getUniqueId()) && !claim.hasExplicitPermission(player, ClaimPermission.Build)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,5 +8,6 @@ softdepend:
   - WorldGuard
   - Factions
   - BaseRaiders
+  - BentoBox
   - Vault
 api-version: '1.21'


### PR DESCRIPTION
Blocks unauthorized players from changing colors on elevators and teleport pads in protected areas. Adds BentoBox island protection support via reflection and a configurable bypass permission.